### PR TITLE
Problem: Missing android build command for simple demo (fix cronos-labs/play-unreal-plugin#238)

### DIFF
--- a/simple/README.md
+++ b/simple/README.md
@@ -75,6 +75,7 @@ If you prefer configuring the project manually,
 ```
 
 ### iOS
+Build iOS on Mac:
 1. Specify a valid Provision and a valid Certificate in Project Settings > Platforms > iOS > Mobile Provision
 2. DISABLE `Support bitcode in shipping` in Project Settings > Platforms > iOS > Build
 3. Setup distribution type based on the iOS profile in Project Settings > Packaging > Project > For Distribution

--- a/simple/README.md
+++ b/simple/README.md
@@ -18,46 +18,69 @@ Download the release zip file in [Release](https://github.com/cronos-labs/play-u
 ## Setup Manually
 If you prefer configuring the project manually:
 1. For windows,
-   - `git clone https://github.com/cronos-labs/play-unreal-plugin.git Plugins/play-unreal-plugin/`
-   - `cd Plugins/play-unreal-plugin/`
-   - `install-play-cpp-sdk.bat`
-   - `cd ../../`
-   - `windows-build.bat`
+``` powershell
+   git clone https://github.com/cronos-labs/play-unreal-plugin.git Plugins\play-unreal-plugin\
+   cd Plugins\play-unreal-plugin\
+   .\install-play-cpp-sdk.bat
+   cd ..\..\
+   .\windows-build.bat
+```
 
 2. For mac or Linux,
-   - `git clone https://github.com/cronos-labs/play-unreal-plugin.git Plugins/play-unreal-plugin/`
-   - `cd Plugins/play-unreal-plugin`
-   - `make`
-   - `cd ../../`
-   - `make`
+``` sh
+   git clone https://github.com/cronos-labs/play-unreal-plugin.git Plugins/play-unreal-plugin/
+   cd Plugins/play-unreal-plugin
+   make
+   cd ../../
+   make
+```
 
 3. For android,
    - Install Android Studio, and download android sdk and ndk
-     - Customize > All Settings > Appearance & Behavior > System Settings > Android SDK > SDK
-       Tools
-     - Android SDK Build-Tools: >= 28
-     - NDK (Side by side): 21.47075529
-   - Setup the key for signing, check
-     [here](https://docs.unrealengine.com/4.27/en-US/SharingAndReleasing/Mobile/Android/DistributionSigning/),
-     or run `./android_key_gen.sh` to generate a test keystore
-   - Project Settings > Platforms > Android SDK ($HOME: replace with the location of your HOME
-     directory)
-     - Location of Android SDK: $HOME/Library/Android/sdk
-     - Location of Android NDK: $HOME/Library/Android/sdk/ndk/21.4.7075529
-     - Location of JAVA: /Applications/Android Studio.app/Contents/jre/Contents/Home
-     - SDK API Level: latest
-     - NDK API Level: android-21
-   - `git clone https://github.com/cronos-labs/play-unreal-plugin.git Plugins/play-unreal-plugin/`
-   - `cd Plugins/play-unreal-plugin/ && make`
-   - `cd ../../ && make android`
+     - Customize > All Settings > Appearance & Behavior > System Settings > Android SDK
+       - SDK Platforms: Android 11.0 (R), API Level 30 (>= 28)
+       - SDK Tools
+         - Android SDK Build-Tools: 30.0.3 (>= 28)
+         - NDK (Side by side): 21.47075529
+   - Build Android on Mac
+    - Setup the key for signing, check
+        [here](https://docs.unrealengine.com/4.27/en-US/SharingAndReleasing/Mobile/Android/DistributionSigning/),
+        or run `./android_key_gen.sh` to generate a test keystore
+    - Project Settings > Platforms > Android SDK ($HOME: replace with the location of your HOME
+        directory)
+        - Location of Android SDK: $HOME/Library/Android/sdk
+        - Location of Android NDK: $HOME/Library/Android/sdk/ndk/21.4.7075529
+        - Location of JAVA: /Applications/Android Studio.app/Contents/jre/Contents/Home
+        - SDK API Level: latest
+        - NDK API Level: android-21
+        - Run:
+        ```sh
+           git clone https://github.com/cronos-labs/play-unreal-plugin.git Plugins/play-unreal-plugin/
+           cd Plugins/play-unreal-plugin/ && make
+           cd ../../ && make android
+        ```
+   - Build Android on Windows
+    - Setup the key for signing, check
+        [here](https://docs.unrealengine.com/4.27/en-US/SharingAndReleasing/Mobile/Android/DistributionSigning/),
+        or run `.\android_key_gen.ps1` to generate a test keystore
+    - Run
+    ``` powershell
+        git clone https://github.com/cronos-labs/play-unreal-plugin.git Plugins/play-unreal-plugin/
+        cd Plugins\play-unreal-plugin\
+        .\install-play-cpp-sdk.bat
+        cd ..\..\
+        .\android-build.ps1
+    ```
 
 4. For ios,
    - Specify a valid Provision and a valid Certificate in Project Settings > Platforms > iOS > Mobile Provision
    - DISABLE `Support bitcode in shipping` in Project Settings > Platforms > iOS > Build
    - Setup distribution type based on the iOS profile in Project Settings > Packaging > Project > For Distribution
-   - `git clone https://github.com/cronos-labs/play-unreal-plugin.git Plugins/play-unreal-plugin/`
-   - `cd Plugins/play-unreal-plugin/ && make`
-   - `cd ../../ && make ios`
+   ```sh
+      git clone https://github.com/cronos-labs/play-unreal-plugin.git Plugins/play-unreal-plugin/
+      cd Plugins/play-unreal-plugin/ && make
+      cd ../../ && make ios
+   ```
 
 ### More information for Cronos Play
 If you are a game developer, please visit [Cronos Play](https://cronos.org/play) or fill this

--- a/simple/README.md
+++ b/simple/README.md
@@ -14,10 +14,10 @@ repository](https://github.com/crypto-com/play-unreal-plugin).
 ## Pre-built Release
 Download the release zip file in [Release](https://github.com/cronos-labs/play-unreal-demo/releases) page.
 
-
 ## Setup Manually
-If you prefer configuring the project manually:
-1. For windows,
+If you prefer configuring the project manually,
+
+### Windows
 ``` powershell
    git clone https://github.com/cronos-labs/play-unreal-plugin.git Plugins\play-unreal-plugin\
    cd Plugins\play-unreal-plugin\
@@ -26,7 +26,7 @@ If you prefer configuring the project manually:
    .\windows-build.bat
 ```
 
-2. For mac or Linux,
+### Mac or Linux
 ``` sh
    git clone https://github.com/cronos-labs/play-unreal-plugin.git Plugins/play-unreal-plugin/
    cd Plugins/play-unreal-plugin
@@ -35,53 +35,55 @@ If you prefer configuring the project manually:
    make
 ```
 
-3. For android,
-   - Install Android Studio, and download android sdk and ndk
-     - Customize > All Settings > Appearance & Behavior > System Settings > Android SDK
-       - SDK Platforms: Android 11.0 (R), API Level 30 (>= 28)
-       - SDK Tools
-         - Android SDK Build-Tools: 30.0.3 (>= 28)
-         - NDK (Side by side): 21.47075529
-   - Build Android on Mac
-    - Setup the key for signing, check
-        [here](https://docs.unrealengine.com/4.27/en-US/SharingAndReleasing/Mobile/Android/DistributionSigning/),
-        or run `./android_key_gen.sh` to generate a test keystore
-    - Project Settings > Platforms > Android SDK ($HOME: replace with the location of your HOME
-        directory)
-        - Location of Android SDK: $HOME/Library/Android/sdk
-        - Location of Android NDK: $HOME/Library/Android/sdk/ndk/21.4.7075529
-        - Location of JAVA: /Applications/Android Studio.app/Contents/jre/Contents/Home
-        - SDK API Level: latest
-        - NDK API Level: android-21
-        - Run:
-        ```sh
-           git clone https://github.com/cronos-labs/play-unreal-plugin.git Plugins/play-unreal-plugin/
-           cd Plugins/play-unreal-plugin/ && make
-           cd ../../ && make android
-        ```
-   - Build Android on Windows
-    - Setup the key for signing, check
-        [here](https://docs.unrealengine.com/4.27/en-US/SharingAndReleasing/Mobile/Android/DistributionSigning/),
-        or run `.\android_key_gen.ps1` to generate a test keystore
-    - Run
-    ``` powershell
-        git clone https://github.com/cronos-labs/play-unreal-plugin.git Plugins/play-unreal-plugin/
-        cd Plugins\play-unreal-plugin\
-        .\install-play-cpp-sdk.bat
-        cd ..\..\
-        .\android-build.ps1
+### Android
+1. Install Android Studio, and download android sdk and ndk
+- Customize > All Settings > Appearance & Behavior > System Settings > Android SDK
+- SDK Platforms: Android 11.0 (R), API Level 30 (>= 28)
+- SDK Tools
+    - Android SDK Build-Tools: 30.0.3 (>= 28)
+    - NDK (Side by side): 21.47075529
+
+2-1. Build Android on Mac
+- Setup the key for signing, check
+    [here](https://docs.unrealengine.com/4.27/en-US/SharingAndReleasing/Mobile/Android/DistributionSigning/),
+    or run `./android_key_gen.sh` to generate a test keystore
+- Project Settings > Platforms > Android SDK ($HOME: replace with the location of your HOME
+    directory)
+    - Location of Android SDK: $HOME/Library/Android/sdk
+    - Location of Android NDK: $HOME/Library/Android/sdk/ndk/21.4.7075529
+    - Location of JAVA: /Applications/Android Studio.app/Contents/jre/Contents/Home
+    - SDK API Level: latest
+    - NDK API Level: android-21
+    - Run:
+    ```sh
+    git clone https://github.com/cronos-labs/play-unreal-plugin.git Plugins/play-unreal-plugin/
+    cd Plugins/play-unreal-plugin/ && make
+    cd ../../ && make android
     ```
 
-4. For ios,
-   - Specify a valid Provision and a valid Certificate in Project Settings > Platforms > iOS > Mobile Provision
-   - DISABLE `Support bitcode in shipping` in Project Settings > Platforms > iOS > Build
-   - Setup distribution type based on the iOS profile in Project Settings > Packaging > Project > For Distribution
-   ```sh
-      git clone https://github.com/cronos-labs/play-unreal-plugin.git Plugins/play-unreal-plugin/
-      cd Plugins/play-unreal-plugin/ && make
-      cd ../../ && make ios
-   ```
+2-2. Build Android on Windows
+- Setup the key for signing, check
+    [here](https://docs.unrealengine.com/4.27/en-US/SharingAndReleasing/Mobile/Android/DistributionSigning/),
+    or run `.\android_key_gen.ps1` to generate a test keystore
+- Run
+``` powershell
+    git clone https://github.com/cronos-labs/play-unreal-plugin.git Plugins/play-unreal-plugin/
+    cd Plugins\play-unreal-plugin\
+    .\install-play-cpp-sdk.bat
+    cd ..\..\
+    .\android-build.ps1
+```
 
-### More information for Cronos Play
+### iOS
+1. Specify a valid Provision and a valid Certificate in Project Settings > Platforms > iOS > Mobile Provision
+2. DISABLE `Support bitcode in shipping` in Project Settings > Platforms > iOS > Build
+3. Setup distribution type based on the iOS profile in Project Settings > Packaging > Project > For Distribution
+```sh
+    git clone https://github.com/cronos-labs/play-unreal-plugin.git Plugins/play-unreal-plugin/
+    cd Plugins/play-unreal-plugin/ && make
+    cd ../../ && make ios
+```
+
+## More information for Cronos Play
 If you are a game developer, please visit [Cronos Play](https://cronos.org/play) or fill this
 [Contact Form](https://airtable.com/shrFiQnLrcpeBp2lS) for more information.

--- a/simple/android-build.ps1
+++ b/simple/android-build.ps1
@@ -1,0 +1,16 @@
+[System.Environment]::SetEnvironmentVariable('JAVA_HOME','C:\Program Files\Android\Android Studio\jre')
+[System.Environment]::SetEnvironmentVariable('ANDROID_HOME',"$env:LOCALAPPDATA\Android\Sdk")
+[System.Environment]::SetEnvironmentVariable('NDKROOT',"$env:LOCALAPPDATA\Android\Sdk\ndk\21.4.7075529")
+
+$curDir = (Get-Item .).FullName
+cmd.exe /c "C:\Program Files\Epic Games\UE_4.27\Engine\Build\BatchFiles\RunUAT.bat" `
+    BuildCookRun `
+    -utf8output `
+    -platform=Android `
+    -cookflavor=ASTC `
+    -clientconfig=Development `
+    -serverconfig=Development `
+    -project="$curDir/CronosPlayUnrealDemo.uproject" `
+    -noP4 -nodebuginfo -allmaps `
+    -cook -build -stage -prereqs -pak -archive `
+    -archivedirectory="$curDir\archive"

--- a/simple/android_key_gen.bat
+++ b/simple/android_key_gen.bat
@@ -1,6 +1,0 @@
-keytool ^
--genkey -v -keystore key.keystore -alias Mykey -keyalg RSA -keysize 2048 -validity 10000 ^
--dname "CN=TestGuy, OU=MyCompany, O=MyGame, L=MyCity, ST=NC, C=00" ^
--storepass 123456 -keypass 123456
-if not exist "Build\Android" mkdir Build\Android
-move key.keystore Build\Android

--- a/simple/android_key_gen.ps1
+++ b/simple/android_key_gen.ps1
@@ -1,0 +1,13 @@
+& "C:\Program Files\Android\Android Studio\jre\bin\keytool.exe" `
+-genkey -v -keystore key.keystore -alias Mykey -keyalg RSA -keysize 2048 -validity 10000 `
+-dname "CN=TestGuy, OU=MyCompany, O=MyGame, L=MyCity, ST=NC, C=00" `
+-storepass 123456 -keypass 123456
+
+$path = "Build\Android"
+If(!(Test-Path -PathType container $path))
+{
+      New-Item -ItemType Directory -Path $path
+}
+
+
+move key.keystore Build\Android


### PR DESCRIPTION
Close:
- cronos-labs/play-unreal-plugin#238

Solutions:
- Add android-build.ps1
- Remove android_key_gen.bat and replace it with android_key_gen.ps1
- Update README