### PR TITLE
Fix: Remove unsed security token

### DIFF
--- a/play2earn/Config/DefaultEngine.ini
+++ b/play2earn/Config/DefaultEngine.ini
@@ -52,7 +52,7 @@ DefaultGraphicsRHI=DefaultGraphicsRHI_DX12
 [/Script/AndroidFileServerEditor.AndroidFileServerRuntimeSettings]
 bEnablePlugin=True
 bAllowNetworkConnection=True
-SecurityToken=956D8B1DFF44D691FE12DF8318960500
+SecurityToken=
 bIncludeInShipping=False
 bAllowExternalStartInShipping=False
 bCompileAFSProject=False
@@ -62,4 +62,3 @@ bReportStats=False
 ConnectionType=USBOnly
 bUseManualIPAddress=False
 ManualIPAddress=
-


### PR DESCRIPTION
It is a random token generated by unreal, remove it and avoid confusion.